### PR TITLE
feat/add-deep-mapping-for-mapOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ class User
         'coerce'  => true,                      // Coerce single elements into an array
         'using'   => [self::class, 'map'],      // Custom mapping function
         'map_via' => 'mapper',                  // Custom mapping method (defaults to 'map')
+        'level' => 1,                           // The dimension of the array. Defaults to 1.
     ])]
     public Collection $Aliases;
 }
@@ -267,4 +268,42 @@ $User = User::from([
 ]);
 
 echo $User->Aliases->items[0]->name; // Outputs: John Doe
+```
+#### Deep Mapping
+
+You can set the level for mapping deep arrays.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+    
+    /** @var Alias[] $Aliases */
+    #[Describe([
+        'cast' => [self::class, 'mapOf'],   // Use the mapOf helper method
+        'type' => Alias::class,             // Target type for each item
+        'level' => 2,                       // The dimension of the array. Defaults to 1.
+    ])]
+    public array $Aliases;
+}
+
+class Alias
+{
+    use \Zerotoprod\DataModel\DataModel;
+    
+    public string $name;
+}
+
+$User = User::from([
+    'Aliases' => [
+        [
+            ['name' => 'John Doe'],
+            ['name' => 'John Smith'],
+        ]
+    ]
+]);
+
+echo $User->Aliases[0][0]->name; // Outputs: John Doe
+echo $User->Aliases[0][1]->name; // Outputs: John Smith
 ```

--- a/tests/Unit/Array/ArrayTest.php
+++ b/tests/Unit/Array/ArrayTest.php
@@ -19,4 +19,26 @@ class ArrayTest extends TestCase
         self::assertEquals('John Doe', $User->Aliases[0]->name);
         self::assertEquals('John Smith', $User->Aliases[1]->name);
     }
+
+    #[Test] public function nested(): void
+    {
+        $User = User::from([
+            'AliasesNested' => [
+                [
+                    ['name' => 'John Doe'],
+                    ['name' => 'John Smith'],
+                ],
+                [
+                    ['name' => 'John Doe'],
+                    ['name' => 'John Smith'],
+                ]
+            ]
+        ]);
+
+        self::assertEquals('John Doe', $User->AliasesNested[0][0]->name);
+        self::assertEquals('John Smith', $User->AliasesNested[0][1]->name);
+
+        self::assertEquals('John Doe', $User->AliasesNested[1][0]->name);
+        self::assertEquals('John Smith', $User->AliasesNested[1][1]->name);
+    }
 }

--- a/tests/Unit/Array/User.php
+++ b/tests/Unit/Array/User.php
@@ -17,4 +17,12 @@ class User
         'type' => Alias::class,
     ])]
     public array $Aliases;
+
+    /** @var Alias[][] $AliasesNested */
+    #[Describe([
+        'cast' => [self::class, 'mapOf'],
+        'type' => Alias::class,
+        'level' => 2,
+    ])]
+    public array $AliasesNested;
 }

--- a/tests/Unit/MapVia/Collection.php
+++ b/tests/Unit/MapVia/Collection.php
@@ -13,7 +13,12 @@ class Collection
     public function mapper(callable $callable): Collection
     {
         $Collection = new self($this->value);
-        $Collection->items = array_map($callable, $this->value);
+        if(isset($this->value->items)){
+            $Collection->items = array_map($callable, (array)$this->value->items);
+
+            return $Collection;
+        }
+        $Collection->items = array_map($callable, $this->value ?? []);
 
         return $Collection;
     }

--- a/tests/Unit/MapVia/MapViaTest.php
+++ b/tests/Unit/MapVia/MapViaTest.php
@@ -15,4 +15,27 @@ class MapViaTest extends TestCase
 
         self::assertEquals('John Doe', $User->Aliases->items[0]->name);
     }
+
+    #[Test] public function nested(): void
+    {
+        $User = User::from([
+            'Aliases' => [['name' => 'John Doe']],
+            'AliasesNested' => [
+                [
+                    ['name' => 'John Doe'],
+                    ['name' => 'John Smith'],
+                ],
+                [
+                    ['name' => 'John Doe'],
+                    ['name' => 'John Smith'],
+                ]
+            ]
+        ]);
+
+        self::assertEquals('John Doe', $User->AliasesNested->items[0]->items[0]->name);
+        self::assertEquals('John Smith', $User->AliasesNested->items[0]->items[1]->name);
+
+        self::assertEquals('John Doe', $User->AliasesNested->items[1]->items[0]->name);
+        self::assertEquals('John Smith', $User->AliasesNested->items[1]->items[1]->name);
+    }
 }

--- a/tests/Unit/MapVia/User.php
+++ b/tests/Unit/MapVia/User.php
@@ -15,7 +15,16 @@ class User
     #[Describe([
         'cast' => [self::class, 'mapOf'],
         'type' => Alias::class,
-        'map_via' => 'mapper'
+        'map_via' => 'mapper',
     ])]
     public Collection $Aliases;
+
+    /** @var Collection<Collection> $AliasesNested */
+    #[Describe([
+        'cast' => [self::class, 'mapOf'],
+        'type' => Alias::class,
+        'map_via' => 'mapper',
+        'level' => 2,
+    ])]
+    public Collection $AliasesNested;
 }


### PR DESCRIPTION
## Description
#### Deep Mapping

You can set the level for mapping deep arrays.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;
    
    /** @var Alias[] $Aliases */
    #[Describe([
        'cast' => [self::class, 'mapOf'],   // Use the mapOf helper method
        'type' => Alias::class,             // Target type for each item
        'level' => 2,                       // The dimension of the array. Defaults to 1.
    ])]
    public array $Aliases;
}

class Alias
{
    use \Zerotoprod\DataModel\DataModel;
    
    public string $name;
}

$User = User::from([
    'Aliases' => [
        [
            ['name' => 'John Doe'],
            ['name' => 'John Smith'],
        ]
    ]
]);

echo $User->Aliases[0][0]->name; // Outputs: John Doe
echo $User->Aliases[0][1]->name; // Outputs: John Smith
```