### PR TITLE
feat/add-support-for-pregReplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,27 @@ Install the package via Composer:
 composer require zero-to-prod/data-model-helper
 ```
 
-### Additional Packages
+## Usage
 
-- [DataModel](https://github.com/zero-to-prod/data-model): Transform data into a class.
-- [DataModelFactory](https://github.com/zero-to-prod/data-model-factory): A factory helper to set the value of your `DataModel`.
-- [Transformable](https://github.com/zero-to-prod/transformable): Transform a `DataModel` into different types.
+### Including the Trait
 
-## Quick Start
+Include the `DataModelHelper` trait in your class to access helper methods:
 
-Here’s how to use the `mapOf` helper with all its arguments:
+```php
+class DataModelHelper
+{
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+}
+```
+
+## Helper Methods
+
+- [mapOf](#mapof): Create a map of any type by using
+- [pregReplace](#pregreplace): Perform a regular expression search and replace.
+
+### `mapOf()`
+
+Create a map of any type by using the `DataModelHelper::mapOf()` method.
 
 ```php
 use Zerotoprod\DataModel\Describe;
@@ -52,22 +64,9 @@ class User
 }
 ```
 
-## Usage
+#### Usage
 
-### Including the Trait
-
-Include the `DataModelHelper` trait in your class to access helper methods:
-
-```php
-class DataModelHelper
-{
-    use \Zerotoprod\DataModelHelper\DataModelHelper;
-}
-```
-
-### mapOf()
-
-The `mapOf()` method returns an array of `Alias` instances.
+In this case the `mapOf()` method returns an array of `Alias` instances.
 
 ```php
 use Zerotoprod\DataModel\Describe;
@@ -415,4 +414,31 @@ $User = User::from([
 ]);
 
 echo $User->Aliases->get('jd1')->name;  // 'John Doe'
+```
+
+### `pregReplace()`
+
+Use `pregReplace()` to perform a regular expression search and replace.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+    
+    public const ascii_only = '/[^\x00-\x7F]/';
+
+    #[Describe([
+        'cast' => [self::class, 'pregReplace'],
+        'pattern' => ascii_only,
+        'replacement' => '!' // defaults to '' when not specified
+    ])]
+    public string $name;
+}
+
+$User = User::from([
+    'name' => 'Trophy🏆',
+]);
+
+echo $User->name; // Outputs: 'Trophy!'
 ```

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "phpunit/phpunit": "*"
   },
   "suggest": {
-    "zero-to-prod/transformable": "Transform a class into different types."
+    "zero-to-prod/transformable": "Transform a class into different types.",
+    "zero-to-prod/data-model-factory": "Factories for a DataModel."
   }
 }

--- a/src/DataModelHelper.php
+++ b/src/DataModelHelper.php
@@ -66,7 +66,7 @@ trait DataModelHelper
                 ? array_map(static fn($item) => $level <= 1
                     ? $args[0]['type']::$method($item)
                     : $mapper($item, $level - 1),
-                        ($args[0]['key_by'] ?? null) && count(array_column($value, ($args[0]['key_by'] ?? null)))
+                    ($args[0]['key_by'] ?? null) && count(array_column($value, ($args[0]['key_by'] ?? null)))
                         ? array_combine(array_column($value, ($args[0]['key_by'] ?? null)), $value)
                         : $value)
                 : (new $type(
@@ -82,5 +82,17 @@ trait DataModelHelper
         };
 
         return $mapper($value, $args[0]['level'] ?? 1);
+    }
+
+    public static function pregReplace(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property): array|string|null
+    {
+        if (!$value) {
+            return $Property->getType()?->allowsNull()
+                ? null
+                : '';
+        }
+        $args = $Attribute?->getArguments();
+
+        return preg_replace($args[0]['pattern'], $args[0]['replacement'] ?? '', $value);
     }
 }

--- a/tests/Unit/MapOf/Array/Alias.php
+++ b/tests/Unit/MapOf/Array/Alias.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Using;
+namespace Tests\Unit\MapOf\Array;
 
 use Zerotoprod\DataModel\DataModel;
 

--- a/tests/Unit/MapOf/Array/ArrayTest.php
+++ b/tests/Unit/MapOf/Array/ArrayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Array;
+namespace Tests\Unit\MapOf\Array;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Unit/MapOf/Array/User.php
+++ b/tests/Unit/MapOf/Array/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Coerced;
+namespace Tests\Unit\MapOf\Array;
 
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
@@ -15,7 +15,14 @@ class User
     #[Describe([
         'cast' => [self::class, 'mapOf'],
         'type' => Alias::class,
-        'coerce' => true
     ])]
     public array $Aliases;
+
+    /** @var Alias[][] $AliasesNested */
+    #[Describe([
+        'cast' => [self::class, 'mapOf'],
+        'type' => Alias::class,
+        'level' => 2,
+    ])]
+    public array $AliasesNested;
 }

--- a/tests/Unit/MapOf/Coerced/Alias.php
+++ b/tests/Unit/MapOf/Coerced/Alias.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\KeyBy;
+namespace Tests\Unit\MapOf\Coerced;
 
 use Zerotoprod\DataModel\DataModel;
 
@@ -8,6 +8,5 @@ class Alias
 {
     use DataModel;
 
-    public string $id;
     public string $name;
 }

--- a/tests/Unit/MapOf/Coerced/CoercedTest.php
+++ b/tests/Unit/MapOf/Coerced/CoercedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Coerced;
+namespace Tests\Unit\MapOf\Coerced;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Unit/MapOf/Coerced/User.php
+++ b/tests/Unit/MapOf/Coerced/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\KeyBy;
+namespace Tests\Unit\MapOf\Coerced;
 
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
@@ -15,16 +15,7 @@ class User
     #[Describe([
         'cast' => [self::class, 'mapOf'],
         'type' => Alias::class,
-        'key_by' => 'id'
+        'coerce' => true
     ])]
     public array $Aliases;
-
-    /** @var Alias[][] $AliasesNested */
-    #[Describe([
-        'cast' => [self::class, 'mapOf'],
-        'type' => Alias::class,
-        'level' => 2,
-        'key_by' => 'id'
-    ])]
-    public array $AliasesNested;
 }

--- a/tests/Unit/MapOf/KeyBy/Alias.php
+++ b/tests/Unit/MapOf/KeyBy/Alias.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\MapVia;
+namespace Tests\Unit\MapOf\KeyBy;
 
 use Zerotoprod\DataModel\DataModel;
 
@@ -8,5 +8,6 @@ class Alias
 {
     use DataModel;
 
+    public string $id;
     public string $name;
 }

--- a/tests/Unit/MapOf/KeyBy/KeyByTest.php
+++ b/tests/Unit/MapOf/KeyBy/KeyByTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\KeyBy;
+namespace Tests\Unit\MapOf\KeyBy;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Unit/MapOf/KeyBy/User.php
+++ b/tests/Unit/MapOf/KeyBy/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Array;
+namespace Tests\Unit\MapOf\KeyBy;
 
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
@@ -15,6 +15,7 @@ class User
     #[Describe([
         'cast' => [self::class, 'mapOf'],
         'type' => Alias::class,
+        'key_by' => 'id'
     ])]
     public array $Aliases;
 
@@ -23,6 +24,7 @@ class User
         'cast' => [self::class, 'mapOf'],
         'type' => Alias::class,
         'level' => 2,
+        'key_by' => 'id'
     ])]
     public array $AliasesNested;
 }

--- a/tests/Unit/MapOf/MapVia/Alias.php
+++ b/tests/Unit/MapOf/MapVia/Alias.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Array;
+namespace Tests\Unit\MapOf\MapVia;
 
 use Zerotoprod\DataModel\DataModel;
 

--- a/tests/Unit/MapOf/MapVia/Collection.php
+++ b/tests/Unit/MapOf/MapVia/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\MapVia;
+namespace Tests\Unit\MapOf\MapVia;
 
 class Collection
 {

--- a/tests/Unit/MapOf/MapVia/MapViaTest.php
+++ b/tests/Unit/MapOf/MapVia/MapViaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\MapVia;
+namespace Tests\Unit\MapOf\MapVia;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Unit/MapOf/MapVia/User.php
+++ b/tests/Unit/MapOf/MapVia/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\MapVia;
+namespace Tests\Unit\MapOf\MapVia;
 
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;

--- a/tests/Unit/MapOf/Using/Alias.php
+++ b/tests/Unit/MapOf/Using/Alias.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Coerced;
+namespace Tests\Unit\MapOf\Using;
 
 use Zerotoprod\DataModel\DataModel;
 

--- a/tests/Unit/MapOf/Using/Collection.php
+++ b/tests/Unit/MapOf/Using/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Using;
+namespace Tests\Unit\MapOf\Using;
 
 class Collection
 {

--- a/tests/Unit/MapOf/Using/User.php
+++ b/tests/Unit/MapOf/Using/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Using;
+namespace Tests\Unit\MapOf\Using;
 
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;

--- a/tests/Unit/MapOf/Using/UsingTest.php
+++ b/tests/Unit/MapOf/Using/UsingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Using;
+namespace Tests\Unit\MapOf\Using;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Unit/PregReplace/PregReplaceTest.php
+++ b/tests/Unit/PregReplace/PregReplaceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\PregReplace;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PregReplaceTest extends TestCase
+{
+    #[Test] public function pattern(): void
+    {
+        $User = User::from([
+            User::name => 'Trophy🏆',
+            User::lastname => 'stop',
+        ]);
+
+        self::assertEquals('Trophy', $User->name);
+        self::assertEquals('1top', $User->lastname);
+    }
+
+    #[Test] public function missing_null_value(): void
+    {
+        $User = User::from([
+            User::lastname => 'stop',
+        ]);
+
+        self::assertNull($User->name);
+        self::assertEquals('1top', $User->lastname);
+    }
+
+    #[Test] public function missing_empty_value(): void
+    {
+        $User = User::from([
+            User::name => 'Trophy🏆',
+        ]);
+
+        self::assertEquals('Trophy', $User->name);
+        self::assertEquals('', $User->lastname);
+    }
+}

--- a/tests/Unit/PregReplace/User.php
+++ b/tests/Unit/PregReplace/User.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\PregReplace;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const name = 'name';
+    public const lastname = 'lastname';
+
+    #[Describe([
+        'cast' => [self::class, 'pregReplace'],
+        'pattern' => '/[^\x00-\x7F]/'
+    ])]
+    public ?string $name;
+
+    #[Describe([
+        'cast' => [self::class, 'pregReplace'],
+        'pattern' => '/s/',
+        'replacement' => '1'
+    ])]
+    public string $lastname;
+}


### PR DESCRIPTION
## Description

### `pregReplace()`

Use `pregReplace()` to perform a regular expression search and replace.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;
    
    public const ascii_only = '/[^\x00-\x7F]/';

    #[Describe([
        'cast' => [self::class, 'pregReplace'],
        'pattern' => ascii_only,
        'replacement' => '!' // defaults to '' when not specified
    ])]
    public string $name;
}

$User = User::from([
    'name' => 'Trophy🏆',
]);

echo $User->name; // Outputs: 'Trophy!'
```