### PR TITLE
feat/add-support-for-url-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ class DataModelHelper
 
 - [mapOf](#mapof): Create a map of any type by using
 - [pregReplace](#pregreplace): Perform a regular expression search and replace.
+- [isUrl](#isurl): Validates a url.
 
-### `mapOf()`
+### `mapOf`
 
 Create a map of any type by using the `DataModelHelper::mapOf()` method.
 
@@ -416,9 +417,9 @@ $User = User::from([
 echo $User->Aliases->get('jd1')->name;  // 'John Doe'
 ```
 
-### `pregReplace()`
+### `pregReplace`
 
-Use `pregReplace()` to perform a regular expression search and replace.
+Use `pregReplace` to perform a regular expression search and replace.
 
 ```php
 class User
@@ -441,4 +442,24 @@ $User = User::from([
 ]);
 
 echo $User->name; // Outputs: 'Trophy!'
+```
+
+### `isUrl`
+
+Use `isUrl` to perform validate a url.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'protocols' => ['http', 'udp'], // Optional. Defaults to all.
+        'on_fail' => [MyAction::class, 'method'], // Optional. Invoked when validation fails.
+        'exception' => InvalidUrlException::class, // Optional. Throws an exception when not url.
+    ])]
+    public string $url;
+}
 ```

--- a/src/DataModelHelper.php
+++ b/src/DataModelHelper.php
@@ -50,38 +50,38 @@ trait DataModelHelper
      */
     public static function mapOf(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property)
     {
-        $args = $Attribute?->getArguments();
-        $value = isset($args[0]['coerce']) && !isset($value[0]) ? [$value] : $value;
+        $args = $Attribute?->getArguments()[0];
+        $value = isset($args['coerce']) && !isset($value[0]) ? [$value] : $value;
 
-        if (isset($args[0]['using'])) {
-            return ($args[0]['using'])($value);
+        if (isset($args['using'])) {
+            return ($args['using'])($value);
         }
 
-        $method = $args[0]['method'] ?? 'from';
+        $method = $args['method'] ?? 'from';
         $type = $Property->getType()?->getName();
-        $map = $args[0]['map_via'] ?? 'map';
+        $map = $args['map_via'] ?? 'map';
 
         $mapper = static function ($value, $level = 1) use ($args, $map, $type, $method, &$mapper) {
             return $type === 'array'
                 ? array_map(static fn($item) => $level <= 1
-                    ? $args[0]['type']::$method($item)
+                    ? $args['type']::$method($item)
                     : $mapper($item, $level - 1),
-                    ($args[0]['key_by'] ?? null) && count(array_column($value, ($args[0]['key_by'] ?? null)))
-                        ? array_combine(array_column($value, ($args[0]['key_by'] ?? null)), $value)
+                    ($args['key_by'] ?? null) && count(array_column($value, ($args['key_by'] ?? null)))
+                        ? array_combine(array_column($value, ($args['key_by'] ?? null)), $value)
                         : $value)
                 : (new $type(
-                    is_callable($args[0]['map'] ?? null)
-                        ? $args[0]['map']($value)
+                    is_callable($args['map'] ?? null)
+                        ? $args['map']($value)
                         : $value
                 ))
                     ->$map(
                         fn($item) => $level <= 1
-                            ? $args[0]['type']::$method($item)
+                            ? $args['type']::$method($item)
                             : $mapper($item, $level - 1)
                     );
         };
 
-        return $mapper($value, $args[0]['level'] ?? 1);
+        return $mapper($value, $args['level'] ?? 1);
     }
 
     /**
@@ -104,8 +104,79 @@ trait DataModelHelper
                 ? null
                 : '';
         }
-        $args = $Attribute?->getArguments();
+        $args = $Attribute?->getArguments()[0];
 
-        return preg_replace($args[0]['pattern'], $args[0]['replacement'] ?? '', $value);
+        return preg_replace($args['pattern'], $args['replacement'] ?? '', $value);
+    }
+
+    /**
+     * Determine if a given value is a valid URL.
+     *  ```
+     *   #[Describe([
+     *       'cast' => [self::class, 'isUrl'],
+     *       'protocols' => ['http', 'udp'], // Optional. Defaults to all.
+     *       'on_fail' => [MyAction::class, 'method'], // Optional. Invoked when validation fails.
+     *       'exception' => InvalidUrlException::class, // Optional. Throws an exception when not url.
+     *   ])]
+     *  ```
+     */
+    public static function isUrl(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property): ?string
+    {
+        if(!$value){
+            return null;
+        }
+
+        $args = $Attribute?->getArguments()[0];
+        if (!is_string($value)) {
+            if (isset($args['on_fail'])) {
+                call_user_func($args['on_fail'], $value, $context, $Attribute, $Property);
+            }
+
+            if (isset($args['exception'])) {
+                throw new $args['exception'];
+            }
+        }
+
+        $protocols = $args['protocols'] ?? [];
+
+        $protocolList = empty($protocols)
+            ? 'aaa|aaas|about|acap|acct|acd|acr|adiumxtra|adt|afp|afs|aim|amss|android|appdata|apt|ark|attachment|aw|barion|beshare|bitcoin|bitcoincash|blob|bolo|browserext|calculator|callto|cap|cast|casts|chrome|chrome-extension|cid|coap|coap\+tcp|coap\+ws|coaps|coaps\+tcp|coaps\+ws|com-eventbrite-attendee|content|conti|crid|cvs|dab|data|dav|diaspora|dict|did|dis|dlna-playcontainer|dlna-playsingle|dns|dntp|dpp|drm|drop|dtn|dvb|ed2k|elsi|example|facetime|fax|feed|feedready|file|filesystem|finger|first-run-pen-experience|fish|fm|ftp|fuchsia-pkg|geo|gg|git|gizmoproject|go|gopher|graph|gtalk|h323|ham|hcap|hcp|http|https|hxxp|hxxps|hydrazone|iax|icap|icon|im|imap|info|iotdisco|ipn|ipp|ipps|irc|irc6|ircs|iris|iris\.beep|iris\.lwz|iris\.xpc|iris\.xpcs|isostore|itms|jabber|jar|jms|keyparc|lastfm|ldap|ldaps|leaptofrogans|lorawan|lvlt|magnet|mailserver|mailto|maps|market|message|mid|mms|modem|mongodb|moz|ms-access|ms-browser-extension|ms-calculator|ms-drive-to|ms-enrollment|ms-excel|ms-eyecontrolspeech|ms-gamebarservices|ms-gamingoverlay|ms-getoffice|ms-help|ms-infopath|ms-inputapp|ms-lockscreencomponent-config|ms-media-stream-id|ms-mixedrealitycapture|ms-mobileplans|ms-officeapp|ms-people|ms-project|ms-powerpoint|ms-publisher|ms-restoretabcompanion|ms-screenclip|ms-screensketch|ms-search|ms-search-repair|ms-secondary-screen-controller|ms-secondary-screen-setup|ms-settings|ms-settings-airplanemode|ms-settings-bluetooth|ms-settings-camera|ms-settings-cellular|ms-settings-cloudstorage|ms-settings-connectabledevices|ms-settings-displays-topology|ms-settings-emailandaccounts|ms-settings-language|ms-settings-location|ms-settings-lock|ms-settings-nfctransactions|ms-settings-notifications|ms-settings-power|ms-settings-privacy|ms-settings-proximity|ms-settings-screenrotation|ms-settings-wifi|ms-settings-workplace|ms-spd|ms-sttoverlay|ms-transit-to|ms-useractivityset|ms-virtualtouchpad|ms-visio|ms-walk-to|ms-whiteboard|ms-whiteboard-cmd|ms-word|msnim|msrp|msrps|mss|mtqp|mumble|mupdate|mvn|news|nfs|ni|nih|nntp|notes|ocf|oid|onenote|onenote-cmd|opaquelocktoken|openpgp4fpr|pack|palm|paparazzi|payto|pkcs11|platform|pop|pres|prospero|proxy|pwid|psyc|pttp|qb|query|redis|rediss|reload|res|resource|rmi|rsync|rtmfp|rtmp|rtsp|rtsps|rtspu|s3|secondlife|service|session|sftp|sgn|shttp|sieve|simpleledger|sip|sips|skype|smb|sms|smtp|snews|snmp|soap\.beep|soap\.beeps|soldat|spiffe|spotify|ssh|steam|stun|stuns|submit|svn|tag|teamspeak|tel|teliaeid|telnet|tftp|tg|things|thismessage|tip|tn3270|tool|ts3server|turn|turns|tv|udp|unreal|urn|ut2004|v-event|vemmi|ventrilo|videotex|vnc|view-source|wais|webcal|wpid|ws|wss|wtai|wyciwyg|xcon|xcon-userid|xfire|xmlrpc\.beep|xmlrpc\.beeps|xmpp|xri|ymsgr|z39\.50|z39\.50r|z39\.50s'
+            : implode('|', $protocols);
+
+        /*
+         * This pattern is derived from Symfony\Component\Validator\Constraints\UrlValidator (5.0.7).
+         *
+         * (c) Fabien Potencier <fabien@symfony.com> http://symfony.com
+         */
+        $pattern = '~^
+            (PROTOCOLS)://                                 # protocol
+            (((?:[\_\.\pL\pN-]|%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%[0-9A-Fa-f]{2})+)@)?  # basic auth
+            (
+                ([\pL\pN\pS\-\_\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                    |                                                 # or
+                \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                    # an IP address
+                    |                                                 # or
+                \[
+                    (?:(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){6})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:::(?:(?:(?:[0-9a-f]{1,4})):){5})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:[0-9a-f]{1,4})))?::(?:(?:(?:[0-9a-f]{1,4})):){4})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,1}(?:(?:[0-9a-f]{1,4})))?::(?:(?:(?:[0-9a-f]{1,4})):){3})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,2}(?:(?:[0-9a-f]{1,4})))?::(?:(?:(?:[0-9a-f]{1,4})):){2})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,3}(?:(?:[0-9a-f]{1,4})))?::(?:(?:[0-9a-f]{1,4})):)(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,4}(?:(?:[0-9a-f]{1,4})))?::)(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,5}(?:(?:[0-9a-f]{1,4})))?::)(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,6}(?:(?:[0-9a-f]{1,4})))?::))))
+                \]  # an IPv6 address
+            )
+            (:[0-9]+)?                              # a port (optional)
+            (?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%[0-9A-Fa-f]{2})* )*          # a path
+            (?:\? (?:[\pL\pN\-._\~!$&\'\[\]()*+,;=:@/?]|%[0-9A-Fa-f]{2})* )?   # a query (optional)
+            (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%[0-9A-Fa-f]{2})* )?       # a fragment (optional)
+        $~ixu';
+
+        $valid = preg_match(str_replace('PROTOCOLS', $protocolList, $pattern), $value) > 0;
+
+        if (!$valid) {
+            if (isset($args['on_fail'])) {
+                call_user_func($args['on_fail'], $value, $context, $Attribute, $Property);
+            }
+            if (isset($args['exception'])) {
+                throw new $args['exception'];
+            }
+        }
+
+        return $value;
     }
 }

--- a/tests/Unit/IsUrl/Callable/InvalidUrl/BadUrlException.php
+++ b/tests/Unit/IsUrl/Callable/InvalidUrl/BadUrlException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Callable\InvalidUrl;
+
+use RuntimeException;
+
+class BadUrlException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsUrl/Callable/InvalidUrl/IsUrlTest.php
+++ b/tests/Unit/IsUrl/Callable/InvalidUrl/IsUrlTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Callable\InvalidUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IsUrlTest extends TestCase
+{
+    #[Test] public function invalid_url(): void
+    {
+        $this->expectException(BadUrlException::class);
+        User::from([
+            User::url => 'invalid_url',
+        ]);
+    }
+}

--- a/tests/Unit/IsUrl/Callable/InvalidUrl/User.php
+++ b/tests/Unit/IsUrl/Callable/InvalidUrl/User.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Callable\InvalidUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const url = 'url';
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'on_fail' => [self::class, 'failed'],
+    ])]
+    public string $url;
+
+    public static function failed(): string
+    {
+        throw new BadUrlException();
+    }
+}

--- a/tests/Unit/IsUrl/Callable/NotString/BadUrlException.php
+++ b/tests/Unit/IsUrl/Callable/NotString/BadUrlException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Callable\NotString;
+
+use RuntimeException;
+
+class BadUrlException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsUrl/Callable/NotString/IsUrlTest.php
+++ b/tests/Unit/IsUrl/Callable/NotString/IsUrlTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Callable\NotString;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IsUrlTest extends TestCase
+{
+    #[Test] public function invalid_url(): void
+    {
+        $this->expectException(BadUrlException::class);
+        User::from([
+            User::url => 1,
+        ]);
+    }
+}

--- a/tests/Unit/IsUrl/Callable/NotString/User.php
+++ b/tests/Unit/IsUrl/Callable/NotString/User.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Callable\NotString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const url = 'url';
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'on_fail' => [self::class, 'failed'],
+    ])]
+    public string $url;
+
+    public static function failed(): string
+    {
+        throw new BadUrlException();
+    }
+}

--- a/tests/Unit/IsUrl/Exception/InvalidUrl/BadUrlException.php
+++ b/tests/Unit/IsUrl/Exception/InvalidUrl/BadUrlException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Exception\InvalidUrl;
+
+use RuntimeException;
+
+class BadUrlException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsUrl/Exception/InvalidUrl/IsUrlTest.php
+++ b/tests/Unit/IsUrl/Exception/InvalidUrl/IsUrlTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Exception\InvalidUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IsUrlTest extends TestCase
+{
+    #[Test] public function invalid_url(): void
+    {
+        $this->expectException(BadUrlException::class);
+        User::from([
+            User::url => 'invalid_url',
+        ]);
+    }
+}

--- a/tests/Unit/IsUrl/Exception/InvalidUrl/User.php
+++ b/tests/Unit/IsUrl/Exception/InvalidUrl/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Exception\InvalidUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const url = 'url';
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'exception' => BadUrlException::class
+    ])]
+    public string $url;
+}

--- a/tests/Unit/IsUrl/Exception/NotString/BadUrlException.php
+++ b/tests/Unit/IsUrl/Exception/NotString/BadUrlException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Exception\NotString;
+
+use RuntimeException;
+
+class BadUrlException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsUrl/Exception/NotString/IsUrlTest.php
+++ b/tests/Unit/IsUrl/Exception/NotString/IsUrlTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Exception\NotString;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IsUrlTest extends TestCase
+{
+    #[Test] public function not_string(): void
+    {
+        $this->expectException(BadUrlException::class);
+        User::from([
+            User::url => 1,
+        ]);
+    }
+}

--- a/tests/Unit/IsUrl/Exception/NotString/User.php
+++ b/tests/Unit/IsUrl/Exception/NotString/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\IsUrl\Exception\NotString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const url = 'url';
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'exception' => BadUrlException::class
+    ])]
+    public string $url;
+}

--- a/tests/Unit/IsUrl/ValidUrl/IsUrlTest.php
+++ b/tests/Unit/IsUrl/ValidUrl/IsUrlTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\IsUrl\ValidUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IsUrlTest extends TestCase
+{
+    #[Test] public function valid_url(): void
+    {
+        $User = User::from([
+            User::url => 'https://example.com/',
+        ]);
+
+        self::assertEquals('https://example.com/', $User->url);
+    }
+
+    #[Test] public function valid_url_with_protocol(): void
+    {
+        $User = User::from([
+            User::url => 'https://example.com/',
+            User::social_url => 'https://example.com/',
+        ]);
+
+        self::assertEquals('https://example.com/', $User->url);
+        self::assertEquals('https://example.com/', $User->social_url);
+    }
+
+    #[Test] public function per_protocol(): void
+    {
+        $User = User::from([
+            User::per_protocol => 'invalid',
+        ]);
+
+        self::assertEquals('invalid', $User->per_protocol);
+    }
+}

--- a/tests/Unit/IsUrl/ValidUrl/User.php
+++ b/tests/Unit/IsUrl/ValidUrl/User.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\IsUrl\ValidUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const url = 'url';
+    public const social_url = 'social_url';
+    public const per_protocol = 'per_protocol';
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl']
+    ])]
+    public ?string $url;
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'protocols' => ['http']
+    ])]
+    public ?string $social_url;
+
+    #[Describe([
+        'cast' => [self::class, 'isUrl'],
+        'protocols' => ['udp']
+    ])]
+    public ?string $per_protocol;
+}


### PR DESCRIPTION
## Description
### `isUrl`

Use `isUrl` to perform validate a url.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;

    #[Describe([
        'cast' => [self::class, 'isUrl'],
        'protocols' => ['http', 'udp'], // Optional. Defaults to all.
        'on_fail' => [MyAction::class, 'method'], // Optional. Invoked when validation fails.
        'exception' => InvalidUrlException::class, // Optional. Throws an exception when not url.
    ])]
    public string $url;
}
```