### PR TITLE
feat/add-support-for-pregMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ class DataModelHelper
 
 - [mapOf](#mapof): Create a map of any type by using
 - [pregReplace](#pregreplace): Perform a regular expression search and replace.
+- [pregMatch](#pregmatch): Perform a regular expression match.
 - [isUrl](#isurl): Validates a url.
 
 ### `mapOf`
@@ -442,6 +443,33 @@ $User = User::from([
 ]);
 
 echo $User->name; // Outputs: 'Trophy!'
+```
+
+### `pregMatch`
+
+Use `pregMatch` to perform a regular expression match.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+
+    #[Describe([
+        'cast' => [self::class, 'pregMatch'],
+        'pattern' => '/s/', // Required
+        'match_on' => 0 // Index of the $matches to return
+        'flags' => PREG_UNMATCHED_AS_NULL
+        'offset' => 0
+    ])]
+    public string $name;
+}
+
+$User = User::from([
+    'name' => 'sarah',
+]);
+
+echo $User->name; // Outputs: 's'
 ```
 
 ### `isUrl`

--- a/src/DataModelHelper.php
+++ b/src/DataModelHelper.php
@@ -117,15 +117,17 @@ trait DataModelHelper
     }
 
     /**
-     * Perform a regular expression search and replace.
+     * Perform a regular expression match.
      *
-     * NOTE: If property allows null, null will be returned, else an empty string.
+     * NOTE: If property allows null, null will be returned.
      *
      * ```
      *  #[Describe([
-     *      'cast' => [self::class, 'pregReplace'],
-     *      'pattern' => '/s/', // any regular expression
-     *      'replacement' => '' // default
+     *      'cast' => [self::class, 'pregMatch'],
+     *      'pattern' => '/s/', // Required
+     *      'match_on' => 0 // Index of the $matches to return
+     *      'flags' => PREG_UNMATCHED_AS_NULL
+     *      'offset' => 0
      *  ])]
      * ```
      */

--- a/src/DataModelHelper.php
+++ b/src/DataModelHelper.php
@@ -110,9 +110,33 @@ trait DataModelHelper
                 ? null
                 : '';
         }
-        $args = $Attribute?->getArguments()[0];
+
+         $args = $Attribute?->getArguments()[0];
 
         return preg_replace($args['pattern'], $args['replacement'] ?? '', $value);
+    }
+
+    /**
+     * Perform a regular expression search and replace.
+     *
+     * NOTE: If property allows null, null will be returned, else an empty string.
+     *
+     * ```
+     *  #[Describe([
+     *      'cast' => [self::class, 'pregReplace'],
+     *      'pattern' => '/s/', // any regular expression
+     *      'replacement' => '' // default
+     *  ])]
+     * ```
+     */
+    public static function pregMatch(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property): array|string|null
+    {
+        $args = $Attribute?->getArguments()[0];
+        preg_match($args['pattern'], $value, $matches, $args['flags'] ?? null, $args['offset'] ?? null);
+
+        return isset($args['match_on'])
+            ? $matches[$args['match_on']]
+            : $matches;
     }
 
     /**

--- a/src/DataModelHelper.php
+++ b/src/DataModelHelper.php
@@ -129,7 +129,7 @@ trait DataModelHelper
      *  ])]
      * ```
      */
-    public static function pregMatch(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property): array|string|null
+    public static function pregMatch(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property)
     {
         if (!$value && $Property->getType()?->allowsNull()) {
             return null;
@@ -142,7 +142,10 @@ trait DataModelHelper
         $args = $Attribute?->getArguments()[0];
         preg_match($args['pattern'], $value, $matches, $args['flags'] ?? 0, $args['offset'] ?? 0);
 
-        return isset($args['match_on'], $matches)
+        if(isset($args['match_on']) && !isset($matches[$args['match_on']])) {
+            return;
+        }
+        return isset($args['match_on'])
             ? $matches[$args['match_on']]
             : $matches;
     }

--- a/src/DataModelHelper.php
+++ b/src/DataModelHelper.php
@@ -111,7 +111,7 @@ trait DataModelHelper
                 : '';
         }
 
-         $args = $Attribute?->getArguments()[0];
+        $args = $Attribute?->getArguments()[0];
 
         return preg_replace($args['pattern'], $args['replacement'] ?? '', $value);
     }
@@ -131,10 +131,18 @@ trait DataModelHelper
      */
     public static function pregMatch(mixed $value, array $context, ?ReflectionAttribute $Attribute, ReflectionProperty $Property): array|string|null
     {
-        $args = $Attribute?->getArguments()[0];
-        preg_match($args['pattern'], $value, $matches, $args['flags'] ?? null, $args['offset'] ?? null);
+        if (!$value && $Property->getType()?->allowsNull()) {
+            return null;
+        }
 
-        return isset($args['match_on'])
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        $args = $Attribute?->getArguments()[0];
+        preg_match($args['pattern'], $value, $matches, $args['flags'] ?? 0, $args['offset'] ?? 0);
+
+        return isset($args['match_on'], $matches)
             ? $matches[$args['match_on']]
             : $matches;
     }

--- a/tests/Unit/PregMatch/PregMatchTest.php
+++ b/tests/Unit/PregMatch/PregMatchTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\PregMatch;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-class PregReplaceTest extends TestCase
+class PregMatchTest extends TestCase
 {
     #[Test] public function pattern(): void
     {
@@ -20,5 +20,12 @@ class PregReplaceTest extends TestCase
         self::assertEquals('s', $User->s);
         self::assertNull($User->as_null);
         self::assertEquals([], $User->offset);
+    }
+
+    #[Test] public function allowsNull(): void
+    {
+        $User = User::from();
+
+        self::assertNull($User->name);
     }
 }

--- a/tests/Unit/PregMatch/PregReplaceTest.php
+++ b/tests/Unit/PregMatch/PregReplaceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\PregMatch;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PregReplaceTest extends TestCase
+{
+    #[Test] public function pattern(): void
+    {
+        $User = User::from([
+            User::name => 'stop',
+            User::s => 'stop',
+            User::as_null => 'top',
+            User::offset => 'stop',
+        ]);
+
+        self::assertEquals(['s'], $User->name);
+        self::assertEquals('s', $User->s);
+        self::assertNull($User->as_null);
+        self::assertEquals([], $User->offset);
+    }
+}

--- a/tests/Unit/PregMatch/User.php
+++ b/tests/Unit/PregMatch/User.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\PregMatch;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const name = 'name';
+    public const s = 's';
+    public const as_null = 'as_null';
+    public const offset = 'offset';
+
+    #[Describe([
+        'cast' => [self::class, 'pregMatch'],
+        'pattern' => '/s/',
+    ])]
+    public array $name;
+
+    #[Describe([
+        'cast' => [self::class, 'pregMatch'],
+        'pattern' => '/s/',
+        'match_on' => 0
+    ])]
+    public string $s;
+
+    #[Describe([
+        'cast' => [self::class, 'pregMatch'],
+        'pattern' => '/s/',
+        'match_on' => 0,
+        'flags' => PREG_UNMATCHED_AS_NULL
+    ])]
+    public ?string $as_null;
+
+    #[Describe([
+        'cast' => [self::class, 'pregMatch'],
+        'pattern' => '/s/',
+        'offset' => 1
+    ])]
+    public array $offset;
+}

--- a/tests/Unit/PregMatch/User.php
+++ b/tests/Unit/PregMatch/User.php
@@ -20,14 +20,14 @@ class User
         'cast' => [self::class, 'pregMatch'],
         'pattern' => '/s/',
     ])]
-    public array $name;
+    public ?array $name;
 
     #[Describe([
         'cast' => [self::class, 'pregMatch'],
         'pattern' => '/s/',
         'match_on' => 0
     ])]
-    public string $s;
+    public ?string $s;
 
     #[Describe([
         'cast' => [self::class, 'pregMatch'],
@@ -42,5 +42,5 @@ class User
         'pattern' => '/s/',
         'offset' => 1
     ])]
-    public array $offset;
+    public ?array $offset;
 }


### PR DESCRIPTION
## Description
### `pregMatch`

Use `pregMatch` to perform a regular expression match.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;

    #[Describe([
        'cast' => [self::class, 'pregMatch'],
        'pattern' => '/s/', // Required
        'match_on' => 0 // Index of the $matches to return
        'flags' => PREG_UNMATCHED_AS_NULL
        'offset' => 0
    ])]
    public string $name;
}

$User = User::from([
    'name' => 'sarah',
]);

echo $User->name; // Outputs: 's'
```