### PR TITLE
feat/add-support-for-checking-emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ class DataModelHelper
 - [pregReplace](#pregreplace): Perform a regular expression search and replace.
 - [pregMatch](#pregmatch): Perform a regular expression match.
 - [isUrl](#isurl): Validates a url.
+- [isEmail](#isemail): Validates an email.
 
 ### `mapOf`
 
@@ -474,7 +475,7 @@ echo $User->name; // Outputs: 's'
 
 ### `isUrl`
 
-Use `isUrl` to perform validate a url.
+Use `isUrl` to validate a url.
 
 ```php
 class User
@@ -486,7 +487,27 @@ class User
         'cast' => [self::class, 'isUrl'],
         'protocols' => ['http', 'udp'], // Optional. Defaults to all.
         'on_fail' => [MyAction::class, 'method'], // Optional. Invoked when validation fails.
-        'exception' => InvalidUrlException::class, // Optional. Throws an exception when not url.
+        'exception' => MyCustomException::class, // Optional. Throws an exception when not url.
+        'required'  // Optional. Throws \Zerotoprod\DataModel\PropertyRequiredException::class
+    ])]
+    public string $url;
+}
+```
+
+### `isEmail`
+
+Use `isEmail` to validate an email.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'on_fail' => [MyAction::class, 'method'], // Optional. Invoked when validation fails.
+        'exception' => MyCustomException::class, // Optional. Throws an exception when not url.
         'required'  // Optional. Throws \Zerotoprod\DataModel\PropertyRequiredException::class
     ])]
     public string $url;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   "require": {
     "php": ">=8.1.0",
     "zero-to-prod/data-model": "^v81.0.0",
-    "zero-to-prod/validate-url": "^71.0"
+    "zero-to-prod/validate-url": "^71.0",
+    "zero-to-prod/validate-email": "^71.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Unit/IsEmail/Callable/InvalidEmail/BadEmailException.php
+++ b/tests/Unit/IsEmail/Callable/InvalidEmail/BadEmailException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Callable\InvalidEmail;
+
+use RuntimeException;
+
+class BadEmailException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsEmail/Callable/InvalidEmail/InvalidEmailTest.php
+++ b/tests/Unit/IsEmail/Callable/InvalidEmail/InvalidEmailTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Callable\InvalidEmail;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class InvalidEmailTest extends TestCase
+{
+    #[Test] public function invalid_email(): void
+    {
+        $this->expectException(BadEmailException::class);
+        User::from([
+            User::email => 'invalid email',
+        ]);
+    }
+}

--- a/tests/Unit/IsEmail/Callable/InvalidEmail/User.php
+++ b/tests/Unit/IsEmail/Callable/InvalidEmail/User.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Callable\InvalidEmail;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'on_fail' => [self::class, 'failed'],
+    ])]
+    public string $email;
+
+    public static function failed(): string
+    {
+        throw new BadEmailException();
+    }
+}

--- a/tests/Unit/IsEmail/Callable/NotString/BadEmailException.php
+++ b/tests/Unit/IsEmail/Callable/NotString/BadEmailException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Callable\NotString;
+
+use RuntimeException;
+
+class BadEmailException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsEmail/Callable/NotString/NotEmailStringTest.php
+++ b/tests/Unit/IsEmail/Callable/NotString/NotEmailStringTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Callable\NotString;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NotEmailStringTest extends TestCase
+{
+    #[Test] public function invalid_email(): void
+    {
+        $this->expectException(BadEmailException::class);
+        User::from([
+            User::email => 1,
+        ]);
+    }
+}

--- a/tests/Unit/IsEmail/Callable/NotString/User.php
+++ b/tests/Unit/IsEmail/Callable/NotString/User.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Callable\NotString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'on_fail' => [self::class, 'failed'],
+    ])]
+    public string $email;
+
+    public static function failed(): string
+    {
+        throw new BadEmailException();
+    }
+}

--- a/tests/Unit/IsEmail/Exception/InvalidUrl/BadEmailException.php
+++ b/tests/Unit/IsEmail/Exception/InvalidUrl/BadEmailException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Exception\InvalidUrl;
+
+use RuntimeException;
+
+class BadEmailException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsEmail/Exception/InvalidUrl/CustomExceptionTest.php
+++ b/tests/Unit/IsEmail/Exception/InvalidUrl/CustomExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Exception\InvalidUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CustomExceptionTest extends TestCase
+{
+    #[Test] public function invalid_email(): void
+    {
+        $this->expectException(BadEmailException::class);
+        User::from([
+            User::email => 'invalid email',
+        ]);
+    }
+}

--- a/tests/Unit/IsEmail/Exception/InvalidUrl/User.php
+++ b/tests/Unit/IsEmail/Exception/InvalidUrl/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Exception\InvalidUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'exception' => BadEmailException::class
+    ])]
+    public string $email;
+}

--- a/tests/Unit/IsEmail/Exception/NotString/BadEmailException.php
+++ b/tests/Unit/IsEmail/Exception/NotString/BadEmailException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Exception\NotString;
+
+use RuntimeException;
+
+class BadEmailException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsEmail/Exception/NotString/NotStringEmailCustomExceptionTest.php
+++ b/tests/Unit/IsEmail/Exception/NotString/NotStringEmailCustomExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Exception\NotString;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NotStringEmailCustomExceptionTest extends TestCase
+{
+    #[Test] public function not_string(): void
+    {
+        $this->expectException(BadEmailException::class);
+        User::from([
+            User::email => 1,
+        ]);
+    }
+}

--- a/tests/Unit/IsEmail/Exception/NotString/User.php
+++ b/tests/Unit/IsEmail/Exception/NotString/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Exception\NotString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'exception' => BadEmailException::class
+    ])]
+    public string $email;
+}

--- a/tests/Unit/IsEmail/NullUrl/NullUrlTest.php
+++ b/tests/Unit/IsEmail/NullUrl/NullUrlTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\IsEmail\NullUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NullUrlTest extends TestCase
+{
+    #[Test] public function null_email(): void
+    {
+        $User = User::from();
+
+        self::assertNull($User->email);
+    }
+}

--- a/tests/Unit/IsEmail/NullUrl/User.php
+++ b/tests/Unit/IsEmail/NullUrl/User.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\IsEmail\NullUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail']
+    ])]
+    public ?string $email;
+}

--- a/tests/Unit/IsEmail/Required/RequiredTest.php
+++ b/tests/Unit/IsEmail/Required/RequiredTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Required;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Zerotoprod\DataModel\PropertyRequiredException;
+
+class RequiredTest extends TestCase
+{
+    #[Test] public function required(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+        $this->expectExceptionMessage('Property `$email` is required.');
+        User::from();
+    }
+
+    #[Test] public function required_alt(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+        User::from([
+            User::email => 'john@example.com'
+        ]);
+    }
+}

--- a/tests/Unit/IsEmail/Required/User.php
+++ b/tests/Unit/IsEmail/Required/User.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\IsEmail\Required;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'required'
+    ])]
+    public string $email;
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail'],
+        'required'
+    ])]
+    public string $social_email;
+}

--- a/tests/Unit/IsEmail/ValidUrl/IsEmailTest.php
+++ b/tests/Unit/IsEmail/ValidUrl/IsEmailTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\IsEmail\ValidUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IsEmailTest extends TestCase
+{
+    #[Test] public function valid_email(): void
+    {
+        $User = User::from([
+            User::email => 'jane@example.com/',
+        ]);
+
+        self::assertEquals('jane@example.com/', $User->email);
+    }
+}

--- a/tests/Unit/IsEmail/ValidUrl/User.php
+++ b/tests/Unit/IsEmail/ValidUrl/User.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\IsEmail\ValidUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail']
+    ])]
+    public ?string $email;
+}


### PR DESCRIPTION
## Description
### `isEmail`

Use `isEmail` to validate an email.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;

    #[Describe([
        'cast' => [self::class, 'isEmail'],
        'on_fail' => [MyAction::class, 'method'], // Optional. Invoked when validation fails.
        'exception' => MyCustomException::class, // Optional. Throws an exception when not url.
        'required'  // Optional. Throws \Zerotoprod\DataModel\PropertyRequiredException::class
    ])]
    public string $url;
}
```