### PR TITLE
Add support for `isMultiple` validator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ echo $User->name; // Outputs: 's'
 
 ### `isUrl`
 
-Use `isUrl` to validate a url.
+Use `isUrl` to validate an url.
 
 ```php
 class User

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ class DataModelHelper
 - [pregMatch](#pregmatch): Perform a regular expression match.
 - [isUrl](#isurl): Validates a url.
 - [isEmail](#isemail): Validates an email.
+- [isMultiple](#ismultiple): Validate a value is a multiple of another.
 
 ### `mapOf`
 
@@ -521,6 +522,27 @@ class User
         'exception' => MyCustomException::class, // Optional. Throws an exception when not url.
         'required'  // Optional. Throws \Zerotoprod\DataModel\PropertyRequiredException::class
     ])]
+    public string $url;
+}
+```
+
+### `isMultiple`
+
+Use `isMultiple` to validate a value is a multiple of another.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+
+     #[Describe([
+         'cast' => [self::class, 'isMultiple'],
+         'of' => 2                                  // The number the value is a multiple of
+         'on_fail' => [MyAction::class, 'method'],  // Optional. Invoked when validation fails.
+         'exception' => MyException::class,         // Optional. Throws an exception when not a valid email.
+         'required',                                // Throws PropertyRequiredException when value not present.
+     ])]
     public string $url;
 }
 ```

--- a/tests/Unit/IsEmail/ValidEmail/IsEmailTest.php
+++ b/tests/Unit/IsEmail/ValidEmail/IsEmailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\IsEmail\ValidUrl;
+namespace Tests\Unit\IsEmail\ValidEmail;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Unit/IsEmail/ValidEmail/User.php
+++ b/tests/Unit/IsEmail/ValidEmail/User.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\IsEmail\ValidEmail;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const email = 'email';
+
+    #[Describe([
+        'cast' => [self::class, 'isEmail']
+    ])]
+    public ?string $email;
+}

--- a/tests/Unit/IsMultiple/Callable/InvalidEmail/InvalidMultipleTest.php
+++ b/tests/Unit/IsMultiple/Callable/InvalidEmail/InvalidMultipleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Callable\InvalidEmail;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class InvalidMultipleTest extends TestCase
+{
+    #[Test] public function invalid_email(): void
+    {
+        $this->expectException(NotMultipleException::class);
+
+        User::from([
+            User::value => 2,
+        ]);
+    }
+}

--- a/tests/Unit/IsMultiple/Callable/InvalidEmail/NotMultipleException.php
+++ b/tests/Unit/IsMultiple/Callable/InvalidEmail/NotMultipleException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Callable\InvalidEmail;
+
+use RuntimeException;
+
+class NotMultipleException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsMultiple/Callable/InvalidEmail/User.php
+++ b/tests/Unit/IsMultiple/Callable/InvalidEmail/User.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Callable\InvalidEmail;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'isMultiple'],
+        'of' => 7,
+        'on_fail' => [self::class, 'failed'],
+    ])]
+    public int $value;
+
+    public static function failed(): string
+    {
+        throw new NotMultipleException();
+    }
+}

--- a/tests/Unit/IsMultiple/Exception/InvalidUrl/CustomExceptionTest.php
+++ b/tests/Unit/IsMultiple/Exception/InvalidUrl/CustomExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Exception\InvalidUrl;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CustomExceptionTest extends TestCase
+{
+    #[Test] public function invalid_email(): void
+    {
+        $this->expectException(NotMultipleException::class);
+        User::from([
+            User::value => 2,
+        ]);
+    }
+}

--- a/tests/Unit/IsMultiple/Exception/InvalidUrl/NotMultipleException.php
+++ b/tests/Unit/IsMultiple/Exception/InvalidUrl/NotMultipleException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Exception\InvalidUrl;
+
+use RuntimeException;
+
+class NotMultipleException extends RuntimeException
+{
+
+}

--- a/tests/Unit/IsMultiple/Exception/InvalidUrl/User.php
+++ b/tests/Unit/IsMultiple/Exception/InvalidUrl/User.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Exception\InvalidUrl;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'isMultiple'],
+        'of' => 3,
+        'exception' => NotMultipleException::class
+    ])]
+    public int $value;
+}

--- a/tests/Unit/IsMultiple/Nullable/User.php
+++ b/tests/Unit/IsMultiple/Nullable/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\IsEmail\ValidUrl;
+namespace Tests\Unit\IsMultiple\Nullable;
 
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
@@ -11,10 +11,11 @@ class User
     use DataModel;
     use DataModelHelper;
 
-    public const email = 'email';
+    public const value = 'value';
 
     #[Describe([
-        'cast' => [self::class, 'isEmail']
+        'cast' => [self::class, 'isMultiple'],
+        'of' => 10
     ])]
-    public ?string $email;
+    public ?int $value;
 }

--- a/tests/Unit/IsMultiple/Nullable/ValidMultipleTest.php
+++ b/tests/Unit/IsMultiple/Nullable/ValidMultipleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Nullable;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ValidMultipleTest extends TestCase
+{
+    #[Test] public function valid(): void
+    {
+        $User = User::from([
+            User::value => null,
+        ]);
+
+        self::assertNull($User->value);
+    }
+}

--- a/tests/Unit/IsMultiple/Required/RequiredTest.php
+++ b/tests/Unit/IsMultiple/Required/RequiredTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Required;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Zerotoprod\DataModel\PropertyRequiredException;
+
+class RequiredTest extends TestCase
+{
+    #[Test] public function required(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+        $this->expectExceptionMessage('Property `$value` is required.');
+        User::from();
+    }
+}

--- a/tests/Unit/IsMultiple/Required/User.php
+++ b/tests/Unit/IsMultiple/Required/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\Required;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'isMultiple'],
+        'required'
+    ])]
+    public string $value;
+}

--- a/tests/Unit/IsMultiple/ValidMultiple/User.php
+++ b/tests/Unit/IsMultiple/ValidMultiple/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\ValidMultiple;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'isMultiple'],
+        'of' => 10
+    ])]
+    public int $value;
+}

--- a/tests/Unit/IsMultiple/ValidMultiple/ValidMultipleTest.php
+++ b/tests/Unit/IsMultiple/ValidMultiple/ValidMultipleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\IsMultiple\ValidMultiple;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ValidMultipleTest extends TestCase
+{
+    #[Test] public function valid(): void
+    {
+        $User = User::from([
+            User::value => 100,
+        ]);
+
+        self::assertEquals(100, $User->value);
+    }
+}


### PR DESCRIPTION
## Description
### `isMultiple`

Use `isMultiple` to validate a value is a multiple of another.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;

     #[Describe([
         'cast' => [self::class, 'isMultiple'],
         'of' => 2                                  // The number the value is a multiple of
         'on_fail' => [MyAction::class, 'method'],  // Optional. Invoked when validation fails.
         'exception' => MyException::class,         // Optional. Throws an exception when not a valid email.
         'required',                                // Throws PropertyRequiredException when value not present.
     ])]
    public string $url;
}
```