### PR TITLE
Add support for `when`;

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,34 @@ class DataModelHelper
 
 ## Helper Methods
 
+- [when](#when): Create a map of any type by using
 - [mapOf](#mapof): Create a map of any type by using
 - [pregReplace](#pregreplace): Perform a regular expression search and replace.
 - [pregMatch](#pregmatch): Perform a regular expression match.
 - [isUrl](#isurl): Validates a url.
 - [isEmail](#isemail): Validates an email.
 - [isMultiple](#ismultiple): Validate a value is a multiple of another.
+
+### `when`
+
+Use `when` to call a function based on a condition.
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+    use \Zerotoprod\DataModelHelper\DataModelHelper;
+
+    #[Describe([
+        'cast' => [self::class, 'when'],
+        'eval' => '$value >= $context["value_2"]' // The expression to evaluate.
+        'true' => [MyAction::class, 'passed'],    // Optional. Invoked when condition is true.
+        'false' => [MyAction::class, 'failed'],   // Optional. Invoked when condition is true.
+        'required',                               // Throws PropertyRequiredException when value not present.
+    ])]
+    public string $value;
+}
+```
 
 ### `mapOf`
 

--- a/tests/Unit/When/Eval/EvalTest.php
+++ b/tests/Unit/When/Eval/EvalTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\When\Eval;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EvalTest extends TestCase
+{
+    #[Test] public function true(): void
+    {
+        $User = User::from([
+            User::value => 100,
+        ]);
+
+        self::assertEquals(1, $User->value);
+    }
+
+    #[Test] public function false(): void
+    {
+        $User = User::from([
+            User::value => 2,
+        ]);
+
+        self::assertEquals(0, $User->value);
+    }
+}

--- a/tests/Unit/When/Eval/User.php
+++ b/tests/Unit/When/Eval/User.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit\When\Eval;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'when'],
+        'eval' => '$value >= 10',
+        'true' => [self::class, 'true'],
+        'false' => [self::class, 'false'],
+    ])]
+    public int $value;
+
+    public static function true(): int
+    {
+        return 1;
+    }
+    public static function false(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/When/Nullable/NullTest.php
+++ b/tests/Unit/When/Nullable/NullTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\When\Nullable;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NullTest extends TestCase
+{
+    #[Test] public function valid(): void
+    {
+        $User = User::from([
+            User::value => null,
+        ]);
+
+        self::assertNull($User->value);
+    }
+}

--- a/tests/Unit/When/Nullable/User.php
+++ b/tests/Unit/When/Nullable/User.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\When\Nullable;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'when'],
+    ])]
+    public ?int $value;
+
+    public static function false(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/When/Required/RequiredTest.php
+++ b/tests/Unit/When/Required/RequiredTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\When\Required;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Zerotoprod\DataModel\PropertyRequiredException;
+
+class RequiredTest extends TestCase
+{
+    #[Test] public function required(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+        $this->expectExceptionMessage('Property `$value` is required.');
+        User::from();
+    }
+}

--- a/tests/Unit/When/Required/User.php
+++ b/tests/Unit/When/Required/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\When\Required;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'when'],
+        'required'
+    ])]
+    public string $value;
+}

--- a/tests/Unit/When/Value/User.php
+++ b/tests/Unit/When/Value/User.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\When\Value;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+use Zerotoprod\DataModelHelper\DataModelHelper;
+
+class User
+{
+    use DataModel;
+    use DataModelHelper;
+
+    public const value = 'value';
+
+    #[Describe([
+        'cast' => [self::class, 'when'],
+        'eval' => '$value >= 10',
+        'false' => [self::class, 'false'],
+    ])]
+    public int $value;
+
+    public static function true(): int
+    {
+        return 1;
+    }
+    public static function false(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/When/Value/ValueTest.php
+++ b/tests/Unit/When/Value/ValueTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\When\Value;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ValueTest extends TestCase
+{
+    #[Test] public function value(): void
+    {
+        $User = User::from([
+            User::value => 100,
+        ]);
+
+        self::assertEquals(100, $User->value);
+    }
+}


### PR DESCRIPTION
## Description

Use `when` to call a function based on a condition.

```php
class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;

    #[Describe([
        'cast' => [self::class, 'when'],
        'eval' => '$value >= $context["value_2"]' // The expression to evaluate.
        'true' => [MyAction::class, 'passed'],    // Optional. Invoked when condition is true.
        'false' => [MyAction::class, 'failed'],   // Optional. Invoked when condition is true.
        'required',                               // Throws PropertyRequiredException when value not present.
    ])]
    public string $value;
}
```