### PR TITLE
maint/add-docs-for-enum-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ class User
 
 In this case the `mapOf()` method returns an array of `Alias` instances.
 
+This method will also work with enums.
+
 ```php
 use Zerotoprod\DataModel\Describe;
 
@@ -134,6 +136,13 @@ class User
         'required',                        // Throws PropertyRequiredException when value not present
     ])]
     public array $Aliases;
+    
+    /** @var Name[] $Names */
+    #[Describe([
+        'cast' => [self::class, 'mapOf'],
+        'type' => Name::class,
+    ])]
+    public ?array $Names;
 }
 
 class Alias
@@ -143,15 +152,27 @@ class Alias
     public string $name;
 }
 
+enum Name: string
+{
+    case Tom = 'Tom';
+    case John = 'John';
+}
+
 $User = User::from([
     'Aliases' => [
         ['name' => 'John Doe'],
         ['name' => 'John Smith'],
+    ],
+    'Names' => [
+        'Tom',
+        'John',
     ]
 ]);
 
 echo $User->Aliases[0]->name; // Outputs: John Doe
 echo $User->Aliases[1]->name; // Outputs: John Smith
+echo $User->Names[0]; // Enum Name::Tom
+echo $User->Names[1]; // Enum Name::John
 ```
 
 #### Laravel Collection Example

--- a/tests/Unit/MapOf/Array/ArrayTest.php
+++ b/tests/Unit/MapOf/Array/ArrayTest.php
@@ -13,11 +13,16 @@ class ArrayTest extends TestCase
             'Aliases' => [
                 ['name' => 'John Doe'],
                 ['name' => 'John Smith'],
+            ],
+            'Names' => [
+                Name::Tom->value,
+                Name::John->value,
             ]
         ]);
 
         self::assertEquals('John Doe', $User->Aliases[0]->name);
         self::assertEquals('John Smith', $User->Aliases[1]->name);
+        self::assertEquals(Name::Tom, $User->Names[0]);
     }
 
     #[Test] public function nested(): void

--- a/tests/Unit/MapOf/Array/Name.php
+++ b/tests/Unit/MapOf/Array/Name.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Unit\MapOf\Array;
+
+enum Name: string
+{
+    case Tom = 'Tom';
+    case John = 'John';
+}

--- a/tests/Unit/MapOf/Array/User.php
+++ b/tests/Unit/MapOf/Array/User.php
@@ -25,4 +25,11 @@ class User
         'level' => 2,
     ])]
     public ?array $AliasesNested;
+
+    /** @var Name[] $Names */
+    #[Describe([
+        'cast' => [self::class, 'mapOf'],
+        'type' => Name::class,
+    ])]
+    public ?array $Names;
 }


### PR DESCRIPTION
## Description

How to use `mapOf` to cast an array of enums.

```php
use Zerotoprod\DataModel\Describe;

class User
{
    use \Zerotoprod\DataModel\DataModel;
    use \Zerotoprod\DataModelHelper\DataModelHelper;
    
    /** @var Name[] $Names */
    #[Describe([
        'cast' => [self::class, 'mapOf'],
        'type' => Name::class,
    ])]
    public ?array $Names;
}

enum Name: string
{
    case Tom = 'Tom';
    case John = 'John';
}

$User = User::from([
    'Names' => [
        'Tom',
        'John',
    ]
]);

echo $User->Names[0]; // Enum Name::Tom
echo $User->Names[1]; // Enum Name::John
```