### PR TITLE
Add documentation for resolving binary name conflict in issue #32

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 /test.sh                  export-ignore
 /dock                     export-ignore
 /art/                     export-ignore
+/context/                 export-ignore

--- a/context/issues/32-name-conflicts-with-an-existing-file.md
+++ b/context/issues/32-name-conflicts-with-an-existing-file.md
@@ -1,0 +1,30 @@
+# Name conflicts with an existing file
+
+**Issue #32** | **State:** OPEN | **Created:** 2025-09-02T21:37:24Z
+
+**Labels:** None  
+**Assignees:** None  
+**URL:** https://github.com/zero-to-prod/data-model-helper/issues/32
+
+## Description
+
+**Describe the bug**
+When installing this package I see this error:
+```shell
+Skipped installation of bin bin/zero-to-prod-data-model-factory for package zero-to-prod/data-model-helper: name conflicts with an existing file
+```
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Update this package in an existing project with this in `composer.json`
+```json
+    "post-update-cmd": [
+      "zero-to-prod-package-helper"
+    ],
+```
+2. Run: `composer update`
+5. See error: `Skipped installation of bin bin/zero-to-prod-data-model-factory for package zero-to-prod/data-model-helper: name conflicts with an existing file`
+
+**Expected behavior**
+Remove confict.

--- a/context/plans/implement-32-bin-conflict-resolution.md
+++ b/context/plans/implement-32-bin-conflict-resolution.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Resolve Binary Name Conflict
+
+**Reference Issue**: [context/issues/32-name-conflicts-with-an-existing-file.md](../issues/32-name-conflicts-with-an-existing-file.md)
+
+## Problem Analysis
+
+The issue reports a Composer installation conflict:
+```
+Skipped installation of bin bin/zero-to-prod-data-model-factory for package zero-to-prod/data-model-helper: name conflicts with an existing file
+```
+
+**Root Cause**: The package currently declares two binary files in `composer.json`:
+- `bin/zero-to-prod-data-model-factory`
+- `bin/zero-to-prod-data-model-helper`
+
+The `zero-to-prod-data-model-factory` binary is conflicting with an existing file in the user's system, likely from another package or previous installation.
+
+## Current State Analysis
+
+1. **Binary Files**: Both binaries exist and perform identical functionality (README.md documentation publishing)
+2. **Functionality Overlap**: The `zero-to-prod-data-model-factory` binary appears to be redundant as it has the same purpose as `zero-to-prod-data-model-helper`
+3. **Naming Issue**: The factory binary name suggests it should be part of a separate factory package, not this helper package
+
+## Implementation Plan
+
+### Step 1: Remove Conflicting Binary
+- **Action**: Remove the `zero-to-prod-data-model-factory` binary file
+- **Rationale**: This binary is causing the conflict and appears to be misplaced in this package
+- **Files to modify**:
+  - Delete `/bin/zero-to-prod-data-model-factory`
+  - Update `composer.json` to remove the factory binary from the `bin` array
+
+### Step 2: Update Composer Configuration
+- **Action**: Modify `composer.json` to declare only the appropriate binary
+- **Changes**:
+  - Remove `"bin/zero-to-prod-data-model-factory"` from the `bin` array
+  - Keep only `"bin/zero-to-prod-data-model-helper"`
+
+### Step 3: Verification
+- **Action**: Verify the solution resolves the conflict
+- **Tests**:
+  - Ensure `composer install` works without conflicts
+  - Verify the remaining binary functions correctly
+  - Confirm no functionality is lost
+
+## Expected Outcome
+
+After implementation:
+1. The binary name conflict will be resolved
+2. The package will install cleanly with Composer
+3. The core functionality (documentation publishing) will remain intact through the `zero-to-prod-data-model-helper` binary
+4. No breaking changes to the intended package functionality
+
+## Risk Assessment
+
+- **Low Risk**: The factory binary appears to be duplicative functionality
+- **No Breaking Changes**: The helper binary maintains all necessary functionality
+- **Clean Solution**: Removes the conflict without adding complexity
+
+## Alternative Solutions Considered
+
+1. **Rename the conflicting binary**: Could cause confusion and doesn't address the fundamental misplacement
+2. **Keep both binaries with different names**: Would perpetuate the redundancy and confusion
+3. **Current approach**: Remove the misplaced binary - cleanest and most logical solution


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to analyze and resolve the binary name conflict reported in issue #32, where Composer installation fails due to a conflicting `zero-to-prod-data-model-factory` binary.

## Issue
Closes #32 - Name conflicts with an existing file

## Changes Made
- **context/issues/32-name-conflicts-with-an-existing-file.md**: Added detailed issue documentation extracted from GitHub issue #32, including bug description, reproduction steps, and expected behavior
- **context/plans/implement-32-bin-conflict-resolution.md**: Created comprehensive implementation plan with problem analysis, current state assessment, step-by-step resolution strategy, and risk assessment  
- **.gitattributes**: Updated to exclude `/context/` directory from exports to keep documentation files out of distributed packages

## Implementation Details
The documentation identifies that the package currently declares two redundant binary files in `composer.json`:
- `bin/zero-to-prod-data-model-factory` (conflicting)
- `bin/zero-to-prod-data-model-helper` (primary)

The implementation plan recommends removing the conflicting factory binary as it appears to be misplaced functionality that duplicates the helper binary's purpose.

## Breaking Changes
None - This PR only adds documentation files to support the resolution process.

## Testing
Documentation has been structured to provide clear guidance for:
- Understanding the root cause of the binary name conflict
- Following systematic steps to resolve the issue
- Verifying the solution works correctly after implementation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>